### PR TITLE
Add /help command to bot

### DIFF
--- a/backend/src/bot.ts
+++ b/backend/src/bot.ts
@@ -39,6 +39,8 @@ export default (app: Probot) => {
             await handleClaimNowCommand(context, app);
         } else if (parseCommand(comment.body, "/stop")) {
             await handleStopCommand(context, app);
+        } else if (parseCommand(comment.body, "/help")) {
+            await handleHelpCommand(context, app);
         }
     });
 
@@ -308,6 +310,13 @@ export default (app: Probot) => {
             app.log.error(error);
             await quietReply(context, `❌ **System Error**: An internal error occurred.`);
         }
+    }
+
+    async function handleHelpCommand(context: Context<"issue_comment.created">, app: Probot) {
+        app.log.info("🔹 Processing /help command...");
+        await context.octokit.issues.createComment(context.issue({
+            body: T.HELP_MESSAGE(BOT_MENTION)
+        }));
     }
 
     // Wrapper to safely reply without crashing if GitHub is down

--- a/backend/src/prompt_template.ts
+++ b/backend/src/prompt_template.ts
@@ -61,3 +61,27 @@ OR
 FAILED
 (Reasoning...)
 `;
+
+export const HELP_MESSAGE = (botMention: string) => `
+### 🤖 GitBounty Help
+Here are the available commands:
+
+- \`/bounty <name> <price> <token> [chain]\`
+  - Creates a new bounty on the issue.
+  - **Example:** \`${botMention} /bounty "Fix UI" 100 USDC NEAR\`
+
+- \`/claim <transaction_id> <pr_number> <wallet_address>\`
+  - Submit a claim for a bounty.
+  - **Example:** \`${botMention} /claim 5f3e... 123 0x123...\`
+
+- \`/claim-now <transaction_id>\`
+  - (Creator Only) Manually authorize a payout.
+  - **Example:** \`${botMention} /claim-now 5f3e...\`
+
+- \`/stop\`
+  - (Creator Only) Stop a pending payout or dispute a claim.
+  - **Example:** \`${botMention} /stop\`
+
+- \`/help\`
+  - Show this help message.
+`;


### PR DESCRIPTION
This PR adds a `/help` command to the bot. 
The command responds with a formatted list of all available commands (`/bounty`, `/claim`, `/claim-now`, `/stop`, `/help`), including their descriptions and usage examples.
This improves user experience by making it easier to discover and use bot functionality.

---
*PR created automatically by Jules for task [10563008761916298346](https://jules.google.com/task/10563008761916298346) started by @AlphaTechini*